### PR TITLE
Add PoshRSJob as a required module

### DIFF
--- a/EsxRunspace.psd1
+++ b/EsxRunspace.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '3.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-#RequiredModules = @()
+RequiredModules = @(@{'ModuleName'='PoshRSJob'})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/EsxRunspace.psd1
+++ b/EsxRunspace.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '3.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{'ModuleName'='PoshRSJob'})
+RequiredModules = @(@{ModuleName='PoshRSJob';ModuleVersion='1.7.3.9'})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
Adding PoshRSJob as a required module in the module manifest will allow for:

- An easy to understand error message if the module is not available to PowerShell
- It will be a dependency and auto install the module if you upload your module to the PSGallery
- It will auto-load the module when your module is loaded into memory
